### PR TITLE
chore: Release `sphinx-v5.0.0`

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sphinx-cli"
-version = "4.5.0"
+version = "5.0.0"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sphinx-core"
-version = "4.5.0"
+version = "5.0.0"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sphinx-derive"
-version = "4.5.0"
+version = "5.0.0"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/eval/Cargo.toml
+++ b/eval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sphinx-eval"
-version = "4.5.0"
+version = "5.0.0"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/helper/Cargo.toml
+++ b/helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sphinx-helper"
-version = "4.5.0"
+version = "5.0.0"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sphinx-primitives"
-version = "4.5.0"
+version = "5.0.0"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sphinx-prover"
-version = "4.5.0"
+version = "5.0.0"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/recursion/circuit/Cargo.toml
+++ b/recursion/circuit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sphinx-recursion-circuit"
-version = "4.5.0"
+version = "5.0.0"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/recursion/compiler/Cargo.toml
+++ b/recursion/compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sphinx-recursion-compiler"
-version = "4.5.0"
+version = "5.0.0"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/recursion/core/Cargo.toml
+++ b/recursion/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sphinx-recursion-core"
-version = "4.5.0"
+version = "5.0.0"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/recursion/gnark-ffi/Cargo.toml
+++ b/recursion/gnark-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sphinx-recursion-gnark-ffi"
-version = "4.5.0"
+version = "5.0.0"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/recursion/program/Cargo.toml
+++ b/recursion/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sphinx-recursion-program"
-version = "4.5.0"
+version = "5.0.0"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sphinx-sdk"
-version = "4.5.0"
+version = "5.0.0"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/tutorials/Cargo.toml
+++ b/tutorials/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tutorials"
-version = "4.5.0"
+version = "5.0.0"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/zkvm/entrypoint/Cargo.toml
+++ b/zkvm/entrypoint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sphinx-zkvm"
-version = "4.5.0"
+version = "5.0.0"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/zkvm/precompiles/Cargo.toml
+++ b/zkvm/precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sphinx-precompiles"
-version = "4.5.0"
+version = "5.0.0"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true


### PR DESCRIPTION
This is an automated release PR for `sphinx` version `5.0.0`.

On merge, this will trigger the [release publish workflow](https://github.com/samuelburnham/sphinx/actions/workflows/tag-release.yml), which will upload a new GitHub release with tag `sphinx-v5.0.0`.

[Workflow run](https://github.com/samuelburnham/sphinx/actions/runs/11053647393)
